### PR TITLE
GeneratorService: added "mapping" association configuration option that ...

### DIFF
--- a/Listener/DeserializationAssociateRelationship.php
+++ b/Listener/DeserializationAssociateRelationship.php
@@ -37,9 +37,10 @@ class DeserializationAssociateRelationship {
                 if (array_key_exists($joinColumnAnnotation->name, $e->getData())) {
                     $idValue = $e->getData();
                     $idValue = $idValue[$joinColumnAnnotation->name];
-                    if ($idValue !== null) {
+                    $referencedColumnName = $joinColumnAnnotation->referencedColumnName ?: 'id';
+                    if ($idValue !== null && $idValue !== '') {
                         $e->setData(
-                            $e->getData() + array($propertyMetadata->name => array('id' => $idValue))
+                            $e->getData() + array($propertyMetadata->name => array($referencedColumnName => $idValue))
                         );
                     } else {
                         $e->setData(

--- a/Service/GeneratorService.php
+++ b/Service/GeneratorService.php
@@ -274,6 +274,7 @@ class GeneratorService {
                     $field['type'] = $this->getEntityColumnType($association['entity'], $annotation->referencedColumnName);
                     $field['useNull'] = true;
                     $association['key'] = $this->convertNaming($annotation->name);
+                    $field['mapping'] = $property->getName() . '.' . $annotation->referencedColumnName;
                     break;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "type": "symfony-bundle",
     "description": "Use ExtJs with Symfony 2",
     "keywords": ["extjs", "bundle", "symfony2"],
-    "homepage": "",
     "license": "MIT",
     "authors": [
         {
@@ -12,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
+        "php": ">=5.4",
         "symfony/symfony": "2.3.*",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
         "jms/serializer": ">=0.12,<0.15-dev",


### PR DESCRIPTION
...is required for correct loading of belongsTo associations from database.

Without the "mapping" configuration key, when loading entities with belongTo associations from database via REST the foreign key field is not correctly set in extjs and so the association gets lost when saving.

This commit adds the mapping configuration to GeneratorService and extends the tests to cover this issue.